### PR TITLE
Use ~ to install node-mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "mapnik": "^3.6.0",
+    "mapnik": "~3.6.0",
     "proj4": "^2.4.3",
     "sakura-node-3": "^3.3.6"
   },


### PR DESCRIPTION
This will protect your module from automatically upgrading to node-mapnik v3.7.0 (when it is published). This in turn will protect your users from breakages if they are running windows.

Refs mapnik/node-mapnik#848